### PR TITLE
feat!: disable phone sleep timer when Measure Screen is shown #17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <queries>
         <intent>


### PR DESCRIPTION
- add permission `WAKE_LOCK` as it is needed to keep phone awak from API 29
- add flag `FLAG_KEEP_SCREEN_ON` to disable phone sleep timer
- formatting